### PR TITLE
Fix number of scrutinizer runs

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -16,5 +16,5 @@ checks:
 
 tools:
     external_code_coverage:
-        runs: 5
+        runs: 3
         timeout: 1200 # Timeout in seconds. 20 minutes


### PR DESCRIPTION
This caused endless "waiting for external code coverage data" at #18 