### PR TITLE
Given non-null default value to the database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - DB=sqlite
 
 addons:
-  mariadb: '10.1'
+  mariadb: '10.3'
 
 branches:
   only:

--- a/lib/Migration/Version2Date20180926055748.php
+++ b/lib/Migration/Version2Date20180926055748.php
@@ -56,6 +56,9 @@ class Version2Date20180926055748 extends SimpleMigrationStep {
 		$codesTable = $schema->getTable('twofactor_admin_codes');
 		$expiresCol = $codesTable->getColumn('expires');
 		$expiresCol->setNotnull(true);
+		$expiresCol->setDefault(0);
+		$idCol = $codesTable->getColumn('id');
+		$idCol->setAutoincrement(true);
 	}
 
 }


### PR DESCRIPTION
Set a default (non-null) value during migration allows to use broader set of mariadb versions.

This PR is motivated by the discussion on #20.

Fixes #20 

At least on my machine this allows the app to be installed successfully. I think this should not affect any future versions as it simply set a feasible (in terms of the DDL) default value, which seems reasonable.

It has to be verified by the main developer that the default value of `0` is a valid solution: That is: Is the `expires` column really a unix timestamp or some other format? My understanding is yes (which is safe) but I am not 100% sure from reading through the code.