### PR TITLE
Bump maximum supported Nextcloud version to 22 (Fixes: #176)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 		<php min-version="7.2" max-version="8.0"/>
 		<database>sqlite</database>
 		<database>mysql</database>
-		<nextcloud min-version="17" max-version="20"/>
+		<nextcloud min-version="17" max-version="22"/>
 	</dependencies>
 
 	<two-factor-providers>


### PR DESCRIPTION
This PR bumps the maximum supported Nextcloud version to 22.

I already added Nextcloud 21 and 22 CI tests in PR #205. So the only missing change is to bump the supported version in `appinfo/info.xml`.

This PR builds on top of #204 and #205.