### PR TITLE
Prepare release 3.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
     name: php${{ matrix.php-versions }}-${{ matrix.databases }} on ${{ matrix.nextcloud-versions }}
     services:
       mysql:
-        image: mariadb
+        image: mariadb:10.5
         ports:
           - 4444:3306/tcp
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 3.1.0 – 2021-07-08
+### Added
+- Nextcloud 21+22 support
+- PHP 8.0 support
+### Changed
+- Moved CI testing to Github actions
+### Fixed
+- Updated NPM dependencies (some with vulnerabilites)
+- Migrated to NPM 7 + NodeJS 14
+- Removed unused PHP imports
+
 ## 3.0.0 – 2020-08-24
 ### Added
 - Nextcloud 20 support

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 		users have lost access to their other 2FA methods or mandatory 2FA without any previously
 		enabled 2FA provider.
 	</description>
-	<version>3.0.0</version>
+	<version>3.1.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorAdmin</namespace>


### PR DESCRIPTION
## 3.1.0 – 2021-07-08
### Added
- Nextcloud 21+22 support
- PHP 8.0 support
### Changed
- Moved CI testing to Github actions
### Fixed
- Updated NPM dependencies (some with vulnerabilites)
- Migrated to NPM 7 + NodeJS 14
- Removed unused PHP imports