### PR TITLE
feat(deps): update support Nextcloud 30-32, PHP 8.1-8.4

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,11 +25,11 @@
 	<category>security</category>
 	<bugs>https://github.com/ChristophWurst/twofactor_admin/issues</bugs>
 	<dependencies>
-		<php min-version="8.0" max-version="8.4"/>
+		<php min-version="8.1" max-version="8.4"/>
 		<database>sqlite</database>
 		<database>mysql</database>
 		<database>pgsql</database>
-		<nextcloud min-version="28" max-version="31"/>
+		<nextcloud min-version="30" max-version="32"/>
 	</dependencies>
 
 	<two-factor-providers>

--- a/tests/Integration/Db/CodeMapperTest.php
+++ b/tests/Integration/Db/CodeMapperTest.php
@@ -12,10 +12,10 @@ namespace OCA\TwoFactorAdmin\Test\Integration\Db;
 use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use ChristophWurst\Nextcloud\Testing\TestUser;
-use OC;
 use OCA\TwoFactorAdmin\Db\Code;
 use OCA\TwoFactorAdmin\Db\CodeMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\Server;
 
 class CodeMapperTest extends TestCase {
 
@@ -28,7 +28,7 @@ class CodeMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->mapper = OC::$server->query(CodeMapper::class);
+		$this->mapper = Server::get(CodeMapper::class);
 	}
 
 	public function testNoEntryExists() {

--- a/tests/Integration/Service/CodeStorageTest.php
+++ b/tests/Integration/Service/CodeStorageTest.php
@@ -12,8 +12,8 @@ namespace OCA\TwoFactorAdmin\Test\Integration;
 use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use ChristophWurst\Nextcloud\Testing\TestUser;
-use OC;
 use OCA\TwoFactorAdmin\Service\CodeStorage;
+use OCP\Server;
 
 class CodeStorageTest extends TestCase {
 
@@ -26,7 +26,7 @@ class CodeStorageTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->codeStorage = OC::$server->query(CodeStorage::class);
+		$this->codeStorage = Server::get(CodeStorage::class);
 	}
 
 	public function testValidateInexistentCode() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use OCP\App\IAppManager;
+use OCP\Server;
+
 require_once __DIR__.'/../../../lib/base.php';
+require_once __DIR__.'/../../../tests/autoload.php';
 require_once __DIR__.'/../vendor/autoload.php';
 
-OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-OC_App::loadApp('twofactor_admin');
+Server::get(IAppManager::class)->loadApp('twofactor_admin');


### PR DESCRIPTION
- Add support for Nextcloud 32
- Drop support for PHP 8.0 and Nextcloud < 30
- Initial work from https://github.com/nextcloud/twofactor_admin/pull/430